### PR TITLE
PrivateRouteのルート分岐条件を修正

### DIFF
--- a/src/Repositories/auth/useLogin.ts
+++ b/src/Repositories/auth/useLogin.ts
@@ -6,15 +6,15 @@ import useAdminState from '../../recoil/adminState/useAdminState'
 import useAuthState from '../../recoil/authState/useAuthState'
 import { create } from '../Repository'
 
-export type authCheck = {
+export type authCheckType = {
   auth: boolean
   admin: boolean
 }
 
 const useLogin = () => {
   const navigate = useNavigate()
-  const { isAdmin } = useAdminState()
-  const { isAuth } = useAuthState()
+  const { isAdmin, setIsAdmin } = useAdminState()
+  const { isAuth, setIsAuth } = useAuthState()
 
   const errorHandler = (code: number) => {
     if (code === 500) {
@@ -32,6 +32,8 @@ const useLogin = () => {
 
   const logout = () => {
     clearStorage()
+    setIsAuth(null)
+    setIsAdmin(null)
     navigate('/login/user')
   }
 

--- a/src/Router/AdminPrivateRoutes.tsx
+++ b/src/Router/AdminPrivateRoutes.tsx
@@ -6,7 +6,7 @@ import useLogin, { authCheck } from '../Repositories/auth/useLogin'
 
 const AdminPrivateRoutes = () => {
   const { isAuth, setIsAuth } = useAuthState()
-  const { isAdmin, setIsAdmin } = useAdminState()
+  const { setIsAdmin } = useAdminState()
   const token = localStorage.getItem('token')
   const { validate } = useLogin()
 
@@ -19,7 +19,20 @@ const AdminPrivateRoutes = () => {
     }
   }, [])
 
-  return isAuth === true && isAdmin === true ? <Outlet /> : <Navigate to="/login/admin" />
+  const switchRoute = () => {
+    // isAuthがnullの場合何もしない
+    if (!isAuth) {
+      return null
+    }
+
+    // isAuthがbooleanの場合t/fによってreturn
+    if (isAuth === true) {
+      return <Outlet />
+    }
+    return <Navigate to="/login/admin" />
+  }
+
+  return switchRoute()
 }
 
 export default AdminPrivateRoutes

--- a/src/Router/AdminPrivateRoutes.tsx
+++ b/src/Router/AdminPrivateRoutes.tsx
@@ -2,37 +2,27 @@ import React, { useEffect } from 'react'
 import { Outlet, Navigate } from 'react-router-dom'
 import useAdminState from '../recoil/adminState/useAdminState'
 import useAuthState from '../recoil/authState/useAuthState'
-import useLogin, { authCheck } from '../Repositories/auth/useLogin'
+import useLogin, { authCheckType } from '../Repositories/auth/useLogin'
 
 const AdminPrivateRoutes = () => {
   const { isAuth, setIsAuth } = useAuthState()
   const { setIsAdmin } = useAdminState()
-  const token = localStorage.getItem('token')
   const { validate } = useLogin()
 
   useEffect(() => {
-    if (token) {
-      validate().then((res: authCheck) => {
-        setIsAuth(res.auth)
-        setIsAdmin(res.admin)
-      })
-    }
+    validate().then((res: authCheckType) => {
+      setIsAuth(res.auth)
+      setIsAdmin(res.admin)
+    })
   }, [])
 
-  const switchRoute = () => {
-    // isAuthがnullの場合何もしない
-    if (!isAuth) {
-      return null
-    }
-
-    // isAuthがbooleanの場合t/fによってreturn
-    if (isAuth === true) {
-      return <Outlet />
-    }
-    return <Navigate to="/login/admin" />
+  // nullなら先にreturn
+  if (isAuth === null) {
+    return null
   }
 
-  return switchRoute()
+  // true/false
+  return isAuth ? <Outlet /> : <Navigate to="/login/admin" />
 }
 
 export default AdminPrivateRoutes

--- a/src/Router/UserPrivateRoutes.tsx
+++ b/src/Router/UserPrivateRoutes.tsx
@@ -19,7 +19,20 @@ const UserPrivateRoutes = () => {
     }
   }, [])
 
-  return isAuth ? <Outlet /> : <Navigate to="/login/user" />
+  const switchRoute = () => {
+    // isAuthがnullの場合何もしない
+    if (!isAuth) {
+      return null
+    }
+
+    // isAuthがbooleanの場合t/fによってreturn
+    if (isAuth === true) {
+      return <Outlet />
+    }
+    return <Navigate to="/login/user" />
+  }
+
+  return switchRoute()
 }
 
 export default UserPrivateRoutes

--- a/src/Router/UserPrivateRoutes.tsx
+++ b/src/Router/UserPrivateRoutes.tsx
@@ -2,37 +2,27 @@ import React, { useEffect } from 'react'
 import { Outlet, Navigate } from 'react-router-dom'
 import useAdminState from '../recoil/adminState/useAdminState'
 import useAuthState from '../recoil/authState/useAuthState'
-import useLogin, { authCheck } from '../Repositories/auth/useLogin'
+import useLogin, { authCheckType } from '../Repositories/auth/useLogin'
 
 const UserPrivateRoutes = () => {
   const { isAuth, setIsAuth } = useAuthState()
   const { setIsAdmin } = useAdminState()
-  const token = localStorage.getItem('token')
   const { validate } = useLogin()
 
   useEffect(() => {
-    if (token) {
-      validate().then((res: authCheck) => {
-        setIsAuth(res.auth)
-        setIsAdmin(res.admin)
-      })
-    }
+    validate().then((res: authCheckType) => {
+      setIsAuth(res.auth)
+      setIsAdmin(res.admin)
+    })
   }, [])
 
-  const switchRoute = () => {
-    // isAuthがnullの場合何もしない
-    if (!isAuth) {
-      return null
-    }
-
-    // isAuthがbooleanの場合t/fによってreturn
-    if (isAuth === true) {
-      return <Outlet />
-    }
-    return <Navigate to="/login/user" />
+  // nullなら先にreturn
+  if (isAuth === null) {
+    return null
   }
 
-  return switchRoute()
+  // true/false
+  return isAuth ? <Outlet /> : <Navigate to="/login/user" />
 }
 
 export default UserPrivateRoutes

--- a/src/recoil/AdminState/AdminState.ts
+++ b/src/recoil/AdminState/AdminState.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil'
 import { recoilKeyHashSet } from '../recoilKeys'
 
-export const adminState = atom({
+export const adminState = atom<boolean | null>({
   key: recoilKeyHashSet.IS_ADMIN,
-  default: false,
+  default: null,
 })

--- a/src/recoil/authState/authState.ts
+++ b/src/recoil/authState/authState.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil'
 import { recoilKeyHashSet } from '../recoilKeys'
 
-export const authState = atom({
+export const authState = atom<boolean | null>({
   key: recoilKeyHashSet.IS_AUTH,
-  default: false,
+  default: null,
 })


### PR DESCRIPTION
authStateのdefaultをnullに変更

PrivateRouteで以下の通り分岐
- nullなら何もしない(初回アクセスで/loginに遷移することの対策)
- trueならログイン
- falseなら/loginに戻る